### PR TITLE
Update JUnit BOM reference in root build file

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -112,6 +112,7 @@ configure(libraryProjects) {
     }
     dependencies {
         api(platform(dependenciesProject))
+        api(platform(rootProject.libs.junit.bom))
         detektPlugins(dependenciesProject)
         testImplementation("org.assertj:assertj-core")
         testImplementation("org.junit.jupiter:junit-jupiter-api")

--- a/dependencies/build.gradle.kts
+++ b/dependencies/build.gradle.kts
@@ -13,7 +13,6 @@
 
 dependencies {
     api(platform(libs.assertj.bom))
-    api(platform(libs.junit.bom))
     constraints {
         api(libs.mockk)
         api(libs.detekt.formatting)


### PR DESCRIPTION
Changes proposed in this pull request:
- Move the JUnit BOM reference from `dependencies/build.gradle.kts` to the root `build.gradle.kts` to ensure consistent dependency management across the project.