### PR TITLE
Update JUnit BOM dependency scope

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -112,7 +112,7 @@ configure(libraryProjects) {
     }
     dependencies {
         api(platform(dependenciesProject))
-        api(platform(rootProject.libs.junit.bom))
+        testImplementation(platform(rootProject.libs.junit.bom))
         detektPlugins(dependenciesProject)
         testImplementation("org.assertj:assertj-core")
         testImplementation("org.junit.jupiter:junit-jupiter-api")


### PR DESCRIPTION
Changes proposed in this pull request:
- Changed the scope of the JUnit BOM dependency from `api` to `testImplementation` to better reflect its usage in the test environment.