### PR TITLE
Add Throwable assertions and refactor tests

### DIFF
--- a/core/src/main/kotlin/me/ahoo/test/asserts/Jdk.kt
+++ b/core/src/main/kotlin/me/ahoo/test/asserts/Jdk.kt
@@ -31,7 +31,6 @@ import org.assertj.core.api.ObjectAssert
 import org.assertj.core.api.OptionalAssert
 import org.assertj.core.api.ShortAssert
 import org.assertj.core.api.StringAssert
-import org.assertj.core.api.ThrowableAssert
 import java.math.BigDecimal
 import java.util.*
 import java.util.stream.Stream
@@ -94,10 +93,6 @@ fun <T> Array<T>?.assert(): ObjectArrayAssert<T> {
 
 fun <T> List<T>??.assert(): ListAssert<T> {
     return ListAssert(this)
-}
-
-fun <T : Throwable> T?.assert(): ThrowableAssert<T> {
-    return ThrowableAssert(this)
 }
 
 fun <T> Optional<T>?.assert(): OptionalAssert<T> {

--- a/core/src/main/kotlin/me/ahoo/test/asserts/Throwable.kt
+++ b/core/src/main/kotlin/me/ahoo/test/asserts/Throwable.kt
@@ -1,0 +1,23 @@
+package me.ahoo.test.asserts
+
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.ThrowableAssert
+import org.assertj.core.error.ShouldBeInstance.shouldBeInstance
+
+fun <T : Throwable> T?.assert(): ThrowableAssert<T> {
+    return ThrowableAssert(this)
+}
+
+@Suppress("UNCHECKED_CAST")
+fun <T : Throwable> assertThrownBy(throwableType: Class<T>, shouldRaiseThrowable: () -> Unit): ThrowableAssert<T> {
+    val throwable = Assertions.catchThrowable(shouldRaiseThrowable)
+    return throwable.assert()
+        .describedAs { "Expected ${throwableType.simpleName} to be thrown, but was: $throwable" }
+        .isNotNull()
+        .overridingErrorMessage(shouldBeInstance(throwable, throwableType).create())
+        .isInstanceOf(throwableType) as ThrowableAssert<T>
+}
+
+inline fun <reified T : Throwable> assertThrownBy(noinline shouldRaiseThrowable: () -> Unit): ThrowableAssert<T> {
+    return assertThrownBy(T::class.java, shouldRaiseThrowable)
+}

--- a/core/src/test/kotlin/me/ahoo/test/asserts/JdkConcurrentTest.kt
+++ b/core/src/test/kotlin/me/ahoo/test/asserts/JdkConcurrentTest.kt
@@ -1,7 +1,6 @@
 package me.ahoo.test.asserts
 
 import io.mockk.mockk
-import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.FutureAssert
 import org.junit.jupiter.api.Test
 import java.util.concurrent.Future
@@ -11,6 +10,6 @@ class JdkConcurrentTest {
     @Test
     fun `given Future when assert then FutureAssert`() {
         val value = mockk<Future<String>>()
-        assertThat(value.assert()).isInstanceOf(FutureAssert::class.java)
+        value.assert().assert().isInstanceOf(FutureAssert::class.java)
     }
 }

--- a/core/src/test/kotlin/me/ahoo/test/asserts/JdkFunctionTest.kt
+++ b/core/src/test/kotlin/me/ahoo/test/asserts/JdkFunctionTest.kt
@@ -1,7 +1,6 @@
 package me.ahoo.test.asserts
 
 import io.mockk.mockk
-import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.PredicateAssert
 import org.junit.jupiter.api.Test
 import java.util.function.Predicate
@@ -10,6 +9,6 @@ class JdkFunctionTest {
     @Test
     fun `given Predicate when assert then PredicateAssert`() {
         val value = mockk<Predicate<String>>()
-        assertThat(value.assert()).isInstanceOf(PredicateAssert::class.java)
+        value.assert().assert().isInstanceOf(PredicateAssert::class.java)
     }
 }

--- a/core/src/test/kotlin/me/ahoo/test/asserts/JdkIOTest.kt
+++ b/core/src/test/kotlin/me/ahoo/test/asserts/JdkIOTest.kt
@@ -1,7 +1,6 @@
 package me.ahoo.test.asserts
 
 import io.mockk.mockk
-import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.FileAssert
 import org.assertj.core.api.PathAssert
 import org.assertj.core.api.UriAssert
@@ -17,24 +16,24 @@ class JdkIOTest {
     @Test
     fun `given Path when assert then PathAssert`() {
         val value = mockk<Path>()
-        assertThat(value.assert()).isInstanceOf(PathAssert::class.java)
+        value.assert().assert().isInstanceOf(PathAssert::class.java)
     }
 
     @Test
     fun `given File when assert then FileAssert`() {
         val value = mockk<File>()
-        assertThat(value.assert()).isInstanceOf(FileAssert::class.java)
+        value.assert().assert().isInstanceOf(FileAssert::class.java)
     }
 
     @Test
     fun `given URL when assert then UrlAssert`() {
         val value = mockk<URL>()
-        assertThat(value.assert()).isInstanceOf(UrlAssert::class.java)
+        value.assert().assert().isInstanceOf(UrlAssert::class.java)
     }
 
     @Test
     fun `given URI when assert then UriAssert`() {
         val value = mockk<URI>()
-        assertThat(value.assert()).isInstanceOf(UriAssert::class.java)
+        value.assert().assert().isInstanceOf(UriAssert::class.java)
     }
 }

--- a/core/src/test/kotlin/me/ahoo/test/asserts/JdkTest.kt
+++ b/core/src/test/kotlin/me/ahoo/test/asserts/JdkTest.kt
@@ -19,7 +19,6 @@ import org.assertj.core.api.ObjectAssert
 import org.assertj.core.api.OptionalAssert
 import org.assertj.core.api.ShortAssert
 import org.assertj.core.api.StringAssert
-import org.assertj.core.api.ThrowableAssert
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.util.Optional
@@ -122,12 +121,6 @@ class JdkTest {
     fun `given List when assert then ListAssert`() {
         val value = listOf("1")
         assertThat(value.assert()).isInstanceOf(ListAssert::class.java)
-    }
-
-    @Test
-    fun `given Throwable when assert then ThrowableAssert`() {
-        val value = Throwable("1")
-        assertThat(value.assert()).isInstanceOf(ThrowableAssert::class.java)
     }
 
     @Test

--- a/core/src/test/kotlin/me/ahoo/test/asserts/JdkTimeTest.kt
+++ b/core/src/test/kotlin/me/ahoo/test/asserts/JdkTimeTest.kt
@@ -1,7 +1,6 @@
 package me.ahoo.test.asserts
 
 import io.mockk.mockk
-import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.DateAssert
 import org.assertj.core.api.DurationAssert
 import org.assertj.core.api.InstantAssert
@@ -32,72 +31,72 @@ class JdkTimeTest {
     @Test
     fun `given Date when assert then DateAssert`() {
         val value = Date()
-        assertThat(value.assert()).isInstanceOf(DateAssert::class.java)
+        value.assert().assert().isInstanceOf(DateAssert::class.java)
     }
 
     @Test
     fun `given ZonedDateTime when assert then ZonedDateTimeAssert`() {
         val value = ZonedDateTime.now()
-        assertThat(value.assert()).isInstanceOf(ZonedDateTimeAssert::class.java)
+        value.assert().assert().isInstanceOf(ZonedDateTimeAssert::class.java)
     }
 
     @Test
     fun `given Temporal when assert then TemporalAssert`() {
         val value = mockk<Temporal>()
-        assertThat(value.assert()).isInstanceOf(TemporalAssert::class.java)
+        value.assert().assert().isInstanceOf(TemporalAssert::class.java)
     }
 
     @Test
     fun `given LocalDateTime when assert then LocalDateTimeAssert`() {
         val value = LocalDateTime.now()
-        assertThat(value.assert()).isInstanceOf(LocalDateTimeAssert::class.java)
+        value.assert().assert().isInstanceOf(LocalDateTimeAssert::class.java)
     }
 
     @Test
     fun `given OffsetDateTime when assert then OffsetDateTimeAssert`() {
         val value = OffsetDateTime.now()
-        assertThat(value.assert()).isInstanceOf(OffsetDateTimeAssert::class.java)
+        value.assert().assert().isInstanceOf(OffsetDateTimeAssert::class.java)
     }
 
     @Test
     fun `given OffsetTime when assert then OffsetTimeAssert`() {
         val value = OffsetTime.now()
-        assertThat(value.assert()).isInstanceOf(OffsetTimeAssert::class.java)
+        value.assert().assert().isInstanceOf(OffsetTimeAssert::class.java)
     }
 
     @Test
     fun `given LocalTime when assert then LocalTimeAssert`() {
         val value = LocalTime.now()
-        assertThat(value.assert()).isInstanceOf(LocalTimeAssert::class.java)
+        value.assert().assert().isInstanceOf(LocalTimeAssert::class.java)
     }
 
     @Test
     fun `given LocalDate when assert then LocalDateAssert`() {
         val value = LocalDate.now()
-        assertThat(value.assert()).isInstanceOf(LocalDateAssert::class.java)
+        value.assert().assert().isInstanceOf(LocalDateAssert::class.java)
     }
 
     @Test
     fun `given YearMonth when assert then YearMonthAssert`() {
         val value = YearMonth.now()
-        assertThat(value.assert()).isInstanceOf(YearMonthAssert::class.java)
+        value.assert().assert().isInstanceOf(YearMonthAssert::class.java)
     }
 
     @Test
     fun `given Instant when assert then InstantAssert`() {
         val value = Instant.now()
-        assertThat(value.assert()).isInstanceOf(InstantAssert::class.java)
+        value.assert().assert().isInstanceOf(InstantAssert::class.java)
     }
 
     @Test
     fun `given Duration when assert then DurationAssert`() {
         val value = Duration.ZERO
-        assertThat(value.assert()).isInstanceOf(DurationAssert::class.java)
+        value.assert().assert().isInstanceOf(DurationAssert::class.java)
     }
 
     @Test
     fun `given Period when assert then PeriodAssert`() {
         val value = Period.ZERO
-        assertThat(value.assert()).isInstanceOf(PeriodAssert::class.java)
+        value.assert().assert().isInstanceOf(PeriodAssert::class.java)
     }
 }

--- a/core/src/test/kotlin/me/ahoo/test/asserts/ThrowableTest.kt
+++ b/core/src/test/kotlin/me/ahoo/test/asserts/ThrowableTest.kt
@@ -1,0 +1,30 @@
+package me.ahoo.test.asserts
+
+import org.assertj.core.api.ThrowableAssert
+import org.junit.jupiter.api.Test
+
+class ThrowableTest {
+
+    @Test
+    fun `given Throwable when assert then ThrowableAssert`() {
+        Throwable("1").assert().assert().isInstanceOf(ThrowableAssert::class.java)
+    }
+
+    @Suppress("TooGenericExceptionThrown")
+    @Test
+    fun `given Throwable Function when assertThrownBy then ThrowableAssert`() {
+        assertThrownBy<Throwable> {
+            throw Throwable("1")
+        }.assert().isInstanceOf(ThrowableAssert::class.java)
+    }
+
+    @Suppress("TooGenericExceptionThrown")
+    @Test
+    fun `given Null when assertThrownBy then throw AssertionError`() {
+        assertThrownBy<AssertionError> {
+            assertThrownBy<Throwable> {
+                null
+            }.assert()
+        }.assert().withFailMessage { "Expected Throwable to be thrown, but was: null" }
+    }
+}


### PR DESCRIPTION
Changes proposed in this pull request:
- Moved `Throwable` related assertions to a new `ThrowableTest` class.
- Refactored existing tests to use the new `assert` and `assertThrownBy` methods.
- Removed redundant `ThrowableAssert` import from multiple files.