### PR TITLE
refactor(docs): remove redundant assert() calls in exception assertion examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,7 +536,7 @@ Asserts that code throws a specific exception type.
 ```kotlin
 assertThrownBy(IllegalArgumentException::class.java) {
     throw IllegalArgumentException("invalid argument")
-}.assert().hasMessage("invalid argument")
+}.hasMessage("invalid argument")
 ```
 
 ##### `assertThrownBy<T : Throwable>(() -> Unit): ThrowableAssert<T>` (reified)
@@ -545,7 +545,7 @@ Asserts that code throws a specific exception type (Kotlin reified version).
 ```kotlin
 assertThrownBy<IllegalArgumentException> {
     throw IllegalArgumentException("invalid argument")
-}.assert().hasMessage("invalid argument")
+}.hasMessage("invalid argument")
 ```
 
 ## Comparison with AssertJ

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -533,7 +533,7 @@ exception.assert()
 ```kotlin
 assertThrownBy(IllegalArgumentException::class.java) {
     throw IllegalArgumentException("invalid argument")
-}.assert().hasMessage("invalid argument")
+}.hasMessage("invalid argument")
 ```
 
 ##### `assertThrownBy<T : Throwable>(() -> Unit): ThrowableAssert<T>` (reified)
@@ -542,7 +542,7 @@ assertThrownBy(IllegalArgumentException::class.java) {
 ```kotlin
 assertThrownBy<IllegalArgumentException> {
     throw IllegalArgumentException("invalid argument")
-}.assert().hasMessage("invalid argument")
+}.hasMessage("invalid argument")
 ```
 
 ## 高级示例

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -580,7 +580,7 @@ Asserts that code throws a specific exception type.
 ```kotlin
 assertThrownBy(IllegalArgumentException::class.java) {
     throw IllegalArgumentException("invalid argument")
-}.assert().hasMessage("invalid argument")
+}.hasMessage("invalid argument")
 ```
 
 ##### `assertThrownBy<T : Throwable>(() -> Unit): ThrowableAssert<T>` (reified)
@@ -589,7 +589,7 @@ Asserts that code throws a specific exception type (Kotlin reified version).
 ```kotlin
 assertThrownBy<IllegalArgumentException> {
     throw IllegalArgumentException("invalid argument")
-}.assert().hasMessage("invalid argument")
+}.hasMessage("invalid argument")
 ```
 
 ## Advanced Usage

--- a/llms.txt
+++ b/llms.txt
@@ -105,7 +105,7 @@ numbers.assert()
 ```kotlin
 assertThrownBy<IllegalArgumentException> {
     throw IllegalArgumentException("error")
-}.assert().hasMessage("error")
+}.hasMessage("error")
 ```
 
 ### Time Assertions


### PR DESCRIPTION


- Removed unnecessary .assert() chain in assertThrownBy examples
- Simplified exception assertion syntax for better readability
- Updated code snippets across multiple documentation files
- Fixed Kotlin code examples in llms.txt, llms-full.txt, README.md and README.zh-CN.md
- Maintained same functionality while reducing verbosity in tests
- Improved consistency of assertion patterns throughout documentation

