### PR TITLE
[chore] : add skills plugin metadata

### DIFF
--- a/skills/plugins.json
+++ b/skills/plugins.json
@@ -1,0 +1,37 @@
+{
+  "schemaVersion": 1,
+  "plugins": [
+    {
+      "name": "ahoo-fluent-assert-skills",
+      "description": "Skills for writing Kotlin tests with FluentAssert's AssertJ-backed .assert() extensions for JDK types, nullable values, exceptions, and custom AssertProvider assertions.",
+      "skills": {
+        "include": [
+          "*"
+        ],
+        "exclude": [
+          "*-workspace"
+        ]
+      },
+      "keywords": [
+        "fluent-assert",
+        "kotlin",
+        "assertj",
+        "testing",
+        "junit5",
+        "assertions"
+      ],
+      "category": "development",
+      "interface": {
+        "displayName": "Ahoo FluentAssert Skills",
+        "capabilities": [
+          "Skills"
+        ],
+        "defaultPrompt": "Help me use FluentAssert skills for Kotlin test assertions."
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `skills/plugins.json` as platform-neutral plugin source metadata for publishing FluentAssert skills.
- Declare a single `ahoo-fluent-assert-skills` plugin for the existing `fluent-assert` skill.
- Keep generated distribution artifacts out of this repository and exclude `*-workspace` skills from publication.

## Validation

- `jq -e . skills/plugins.json`
- Confirmed `skills/` currently contains `fluent-assert` and no `*-workspace` skill directories.