### PR TITLE
[fix] : address code review findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ person.assert()
     .hasFieldOrPropertyWithValue("name", "John")
 ```
 
-##### `<T : Comparable<T>?> T.assert(): GenericComparableAssert<T>`
+##### `<T : Comparable<T>?> T?.assert(): GenericComparableAssert<T>`
 Creates assertions for comparable objects.
 
 ```kotlin
@@ -249,6 +249,8 @@ array.assert()
     .contains("b")
     .doesNotContain("d")
 ```
+
+> **Note**: Primitive arrays (`IntArray`, `LongArray`, `ByteArray`, etc.) are not covered by `Array<T>` — call `.toTypedArray()` or `.toList()` first to get the array/list assertion APIs.
 
 ##### `<T> List<T>?.assert(): ListAssert<T>`
 Creates assertions for lists.
@@ -488,7 +490,7 @@ future.assert()
     .isCompletedWithValue("success")
 ```
 
-##### `<V> CompletionStage<V>?.assert(): CompletionStageAssert<V>`
+##### `<V> CompletionStage<V>?.assert(): CompletableFutureAssert<V>`
 Creates assertions for CompletionStage objects.
 
 ```kotlin

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -193,7 +193,7 @@ person.assert()
     .hasFieldOrPropertyWithValue("name", "John")
 ```
 
-##### `<T : Comparable<T>?> T.assert(): GenericComparableAssert<T>`
+##### `<T : Comparable<T>?> T?.assert(): GenericComparableAssert<T>`
 为可比较对象创建断言。
 
 ```kotlin
@@ -246,6 +246,8 @@ array.assert()
     .contains("b")
     .doesNotContain("d")
 ```
+
+> **注意**：原生类型数组（`IntArray`、`LongArray`、`ByteArray` 等）不在 `Array<T>` 覆盖范围内——请先调用 `.toTypedArray()` 或 `.toList()` 以获得数组/列表断言 API。
 
 ##### `<T> List<T>?.assert(): ListAssert<T>`
 为列表创建断言。
@@ -485,7 +487,7 @@ future.assert()
     .isCompletedWithValue("success")
 ```
 
-##### `<V> CompletionStage<V>?.assert(): CompletionStageAssert<V>`
+##### `<V> CompletionStage<V>?.assert(): CompletableFutureAssert<V>`
 为CompletionStage对象创建断言。
 
 ```kotlin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,7 +68,7 @@ configure(libraryProjects) {
     configure<DetektExtension> {
         config.setFrom(files("${rootProject.rootDir}/config/detekt/detekt.yml"))
         buildUponDefaultConfig = true
-        autoCorrect = true
+        autoCorrect = false
     }
     apply<DokkaPlugin>()
     apply<JacocoPlugin>()
@@ -106,9 +106,6 @@ configure(libraryProjects) {
             }
             failOnPassedAfterRetry = true
         }
-    }
-    tasks.withType<JavaCompile> {
-        options.compilerArgs.addAll(listOf("-parameters"))
     }
     dependencies {
         api(platform(dependenciesProject))

--- a/core/src/main/kotlin/me/ahoo/test/asserts/Jdk.kt
+++ b/core/src/main/kotlin/me/ahoo/test/asserts/Jdk.kt
@@ -371,7 +371,8 @@ fun <T> Stream<T>?.assert(): ListAssert<T> = assertThat(this)
  * ```
  *
  * @param T The comparable type (must implement Comparable<T>)
- * @receiver T The comparable object to assert on
+ * @receiver T? The comparable object to assert on (nullable)
  * @return GenericComparableAssert<T> A fluent assertion object for comparable objects
  */
-fun <T : Comparable<T>?> T.assert(): GenericComparableAssert<T> = GenericComparableAssert(this)
+@Suppress("UNCHECKED_CAST")
+fun <T : Comparable<T>?> T?.assert(): GenericComparableAssert<T> = GenericComparableAssert(this as T)

--- a/core/src/main/kotlin/me/ahoo/test/asserts/JdkTime.kt
+++ b/core/src/main/kotlin/me/ahoo/test/asserts/JdkTime.kt
@@ -40,6 +40,11 @@ import java.time.ZonedDateTime
 import java.time.temporal.Temporal
 import java.util.*
 
+// AssertJ's assertThat(Temporal) factories return wildcard-typed self-references
+// (e.g. AbstractLocalDateAssert<?>); the casts below narrow the static type to the
+// concrete assertion class, which is required because most of these classes expose
+// no public constructor.
+
 /**
  * Creates a fluent assertion for Date objects.
  *

--- a/core/src/main/kotlin/me/ahoo/test/asserts/Throwable.kt
+++ b/core/src/main/kotlin/me/ahoo/test/asserts/Throwable.kt
@@ -1,3 +1,16 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package me.ahoo.test.asserts
 
 import org.assertj.core.api.Assertions

--- a/core/src/test/kotlin/me/ahoo/test/asserts/JdkTest.kt
+++ b/core/src/test/kotlin/me/ahoo/test/asserts/JdkTest.kt
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.util.Optional
 import java.util.stream.Stream
-import kotlin.jvm.java
 
 class JdkTest {
 
@@ -152,6 +151,12 @@ class JdkTest {
     @Test
     fun `given ComparableObj when assert then GenericComparableAssert`() {
         val value = ComparableObj("1")
+        value.assert().assert().isInstanceOf(GenericComparableAssert::class.java)
+    }
+
+    @Test
+    fun `given NullableComparableObj when assert then GenericComparableAssert`() {
+        val value: ComparableObj? = null
         value.assert().assert().isInstanceOf(GenericComparableAssert::class.java)
     }
 


### PR DESCRIPTION
## Summary

Addresses findings from a full code review of the library (API correctness, test quality, build configuration).

### Changes

**fix(core) — nullable Comparable receivers** ([TDD: RED → GREEN](https://github.com/Ahoo-Wang/FluentAssert/commit/ac6303e))
- `Comparable` values with a nullable static type previously resolved to `ObjectAssert`; the receiver is now nullable so both null and non-null comparables get `GenericComparableAssert`, matching the library's nullable-receiver convention.
- Added `given NullableComparableObj when assert then GenericComparableAssert` regression test.
- Removed an unused `kotlin.jvm.java` import from `JdkTest`.

**chore(core)** — added the missing Apache 2.0 license header to `Throwable.kt` (only main source file without one); added a comment in `JdkTime.kt` explaining why the temporal assertion classes require the `as` casts (AssertJ factories return wildcard self-references; most concrete classes expose no public constructor).

**chore(build)** — removed a duplicated `JavaCompile` configuration block; set `detekt.autoCorrect = false` so `./gradlew detekt` reports violations without silently rewriting files, matching the documented `--auto-correct` workflow in AGENTS.md.

**docs(readme)** — fixed the documented return type of `CompletionStage<V>?.assert()` (`CompletionStageAssert<V>` → `CompletableFutureAssert<V>`, both languages); updated the Comparable signature to `T?.assert()`; added a note that primitive arrays (`IntArray` etc.) fall back to `ObjectAssert` and should be converted with `.toTypedArray()`/`.toList()`.

### Verification

- `./gradlew :core:test` — all green (including the new regression test)
- `./gradlew detekt` — all green

### Not included (pending decision)

- Pinning `actions/checkout@master` to a version tag/SHA in CI workflows
- Removing the logback config referenced by test JVM args (no logback dependency on the test classpath)