### PR TITLE
[skills] : fix API facts and add overload-resolution traps to fluent-assert skill

### DIFF
--- a/skills/fluent-assert/SKILL.md
+++ b/skills/fluent-assert/SKILL.md
@@ -70,6 +70,9 @@ Only use direct `assertThat` when implementing the provider's `assertThat()` met
 - Do not use unavailable AssertJ shortcuts like `OffsetDateTimeAssert.hasOffset(...)`.
 - Do not use numeric `hasMonth(4)` for `LocalDate` or `YearMonth`; use `hasMonth(Month.APRIL)`.
 - Do not switch to `assertThat(value).usingRecursiveComparison()`; keep chaining from `value.assert()`.
+- Do not call `.assert()` on primitive arrays (`IntArray`, `LongArray`, ...) — they fall back to `ObjectAssert` with no collection APIs. Convert first: `ints.toList().assert().hasSize(3).contains(42)`.
+- Do not expect string assertions from non-`String` text receivers. A statically `CharSequence`-typed value resolves to `ObjectAssert`; `StringBuilder` (it implements `Comparable<StringBuilder>`) resolves to `GenericComparableAssert`. Use a `String` (`.toString()`) instead.
+- There is no `CompletionStageAssert`; `stage.assert()` returns `CompletableFutureAssert`.
 
 ## References
 

--- a/skills/fluent-assert/evals/evals.json
+++ b/skills/fluent-assert/evals/evals.json
@@ -35,6 +35,16 @@
       "id": 7,
       "prompt": "Write a test that asserts a custom data class Person(name: String, age: Int) equals expectedPerson using recursive comparison, then verifies the age is greater than 18.",
       "expected_output": "person.assert().usingRecursiveComparison().isEqualTo(expectedPerson) and person.age.assert().isGreaterThan(18)"
+    },
+    {
+      "id": 8,
+      "prompt": "Write a test that verifies an IntArray returned by a function has 3 elements and contains 42.",
+      "expected_output": "Convert before asserting: ints.toList().assert().hasSize(3).contains(42) — primitive arrays only get ObjectAssert"
+    },
+    {
+      "id": 9,
+      "prompt": "Write a test that asserts a CompletionStage<String> completes with the value \"done\".",
+      "expected_output": "stage.assert().isCompletedWithValue(\"done\") — CompletionStage.assert() returns CompletableFutureAssert"
     }
   ]
 }

--- a/skills/fluent-assert/references/FULL-API.md
+++ b/skills/fluent-assert/references/FULL-API.md
@@ -55,8 +55,9 @@ All extension functions follow the pattern `Type.assert(): AssertJTypeAssert`, w
 ```kotlin
 import me.ahoo.test.asserts.assert
 import me.ahoo.test.asserts.assertThrownBy
-import java.time.*
 ```
+
+Import the specific `java.time` / `java.util` types a test uses (e.g. `import java.time.Month`); wildcard imports are only allowed for the packages listed in `config/detekt/detekt.yml` (e.g. `java.util.*`, `org.junit.jupiter.api.Assertions.*`) — others fail the repo's lint.
 
 ## Supported Types
 
@@ -92,6 +93,8 @@ import java.time.*
 | `Optional<T>?` | `OptionalAssert<T>` |
 | `Stream<T>?` | `ListAssert<T>` |
 
+> Primitive arrays (`IntArray`, `LongArray`, `ByteArray`, `CharArray`, ...) are **not** covered by `Array<T>` and fall back to `ObjectAssert`. Convert first: `ints.toList().assert().hasSize(3).contains(42)` or `ints.toTypedArray().assert()`.
+
 ### Time/Date
 
 | Type | Assertion Class |
@@ -124,7 +127,7 @@ import java.time.*
 |------|-----------------|
 | `Future<V>?` | `FutureAssert<V>` |
 | `CompletableFuture<V>?` | `CompletableFutureAssert<V>` |
-| `CompletionStage<V>?` | `CompletionStageAssert<V>` |
+| `CompletionStage<V>?` | `CompletableFutureAssert<V>` |
 
 ### Functional
 
@@ -136,7 +139,16 @@ import java.time.*
 
 | Type | Assertion Class |
 |------|-----------------|
-| `Throwable?` | `ThrowableAssert<Throwable>` |
+| `Throwable?` | `ThrowableAssert<T>` |
+
+### Catch-Alls
+
+| Type | Assertion Class |
+|------|-----------------|
+| `T?` (any object) | `ObjectAssert<T>` |
+| `T : Comparable<T>?` | `GenericComparableAssert<T>` |
+
+Non-`String` text receivers lose string assertions: a statically `CharSequence`-typed value resolves to `ObjectAssert`, and `StringBuilder` (it implements `Comparable<StringBuilder>`) resolves to `GenericComparableAssert<StringBuilder>` — call `.toString()` first for `StringAssert`.
 
 ## API Examples
 
@@ -224,11 +236,16 @@ person.assert()
 
 #### Comparable
 
+Arbitrary `Comparable` types get `GenericComparableAssert` (note: a `String` receiver would resolve to the more specific `StringAssert` instead):
+
 ```kotlin
-val version = "2.0.0"
-version.assert()
-    .isGreaterThan("1.0.0")
-    .isLessThan("3.0.0")
+class Version(val value: Int) : Comparable<Version> {
+    override fun compareTo(other: Version): Int = value.compareTo(other.value)
+}
+
+Version(2).assert()
+    .isGreaterThan(Version(1))
+    .isLessThan(Version(3))
 ```
 
 ### Collections
@@ -488,6 +505,8 @@ future.assert()
 ```
 
 #### CompletionStage
+
+There is no `CompletionStageAssert` — `CompletionStage.assert()` returns `CompletableFutureAssert`:
 
 ```kotlin
 val stage = CompletableFuture.completedFuture("result")


### PR DESCRIPTION
## Summary

Reviewed the `skills/fluent-assert/` plugin sources against the actual library code and fixed every inaccurate or missing claim. All changes are verified by compiling and running the updated examples against `:core`, then re-verified by an independent compiler-based code review.

### Fixed (fact errors)

- **`references/FULL-API.md`**: the supported-types table listed `CompletionStage<V>?` → `CompletionStageAssert<V>` — that class does not exist. The actual return type is `CompletableFutureAssert<V>` (`JdkConcurrent.kt`), now fixed in both the table and the example section with an explicit note.
- **`references/FULL-API.md`**: the import section suggested `import java.time.*`, which violates this repo's Detekt `WildcardImport` config. Replaced with explicit-import guidance that references the allowlist in `config/detekt/detekt.yml`.
- **`references/FULL-API.md`**: the Comparable example used a `String` receiver, which resolves to `StringAssert` and never exercises the `GenericComparableAssert` overload it was meant to demonstrate. Replaced with a custom `Version : Comparable<Version>` example.

### Added (overload-resolution traps, all compiler-verified)

- **`references/FULL-API.md`**: catch-all table rows for `T?` → `ObjectAssert<T>` and `T : Comparable<T>?` → `GenericComparableAssert<T>`; a note that primitive arrays (`IntArray`, ...) fall back to `ObjectAssert`; a note on non-`String` text receivers — a statically `CharSequence`-typed value resolves to `ObjectAssert`, while `StringBuilder` (it implements `Comparable<StringBuilder>`) resolves to `GenericComparableAssert<StringBuilder>`; call `.toString()` for `StringAssert`.
- **`SKILL.md`** (Avoid section): three new traps — primitive arrays need `.toList()`/`.toTypedArray()` first, non-`String` text receivers lose string assertions, and there is no `CompletionStageAssert`.
- **`evals/evals.json`**: two regression prompts (id 8 primitive array, id 9 CompletionStage) locking in the new guidance.

### Verification

1. Every corrected example was placed in a temporary test class and run with `./gradlew :core:test` — all green (temporary file deleted afterwards).
2. Eval per the skill-creator loop: a fresh-context subagent given only the updated `SKILL.md` plus the two trap prompts produced `numbers().toList().assert().hasSize(3).contains(42)` and `process().assert().isCompletedWithValue("done")` — the generated code was also compile-verified.
3. Independent code review (compiler-based): confirmed 9/10 claims correct and caught one error in the initial draft — `StringBuilder` was listed as resolving to `ObjectAssert`, but it implements `Comparable<StringBuilder>` and actually resolves to `GenericComparableAssert<StringBuilder>`. Fixed and re-verified by scratch tests (`StringBuilder` → `GenericComparableAssert`, statically-`CharSequence` → `ObjectAssert`, `.toString()` → `StringAssert`).

`plugins.json` and `agents/openai.yaml` are pure metadata and checked out fine — unchanged.
