### PR TITLE
[docs] : replace misleading String Comparable examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,13 +197,16 @@ person.assert()
 ```
 
 ##### `<T : Comparable<T>?> T?.assert(): GenericComparableAssert<T>`
-Creates assertions for comparable objects.
+Creates assertions for comparable objects. Note that a `String` receiver resolves to `StringAssert` instead.
 
 ```kotlin
-val version = "2.0.0"
-version.assert()
-    .isGreaterThan("1.0.0")
-    .isLessThan("3.0.0")
+class Version(val value: Int) : Comparable<Version> {
+    override fun compareTo(other: Version): Int = value.compareTo(other.value)
+}
+
+Version(2).assert()
+    .isGreaterThan(Version(1))
+    .isLessThan(Version(3))
 ```
 
 ### Collections

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -194,13 +194,16 @@ person.assert()
 ```
 
 ##### `<T : Comparable<T>?> T?.assert(): GenericComparableAssert<T>`
-为可比较对象创建断言。
+为可比较对象创建断言。注意：`String` 接收者会解析到更具体的 `StringAssert`。
 
 ```kotlin
-val version = "2.0.0"
-version.assert()
-    .isGreaterThan("1.0.0")
-    .isLessThan("3.0.0")
+class Version(val value: Int) : Comparable<Version> {
+    override fun compareTo(other: Version): Int = value.compareTo(other.value)
+}
+
+Version(2).assert()
+    .isGreaterThan(Version(1))
+    .isLessThan(Version(3))
 ```
 
 ### 集合

--- a/core/src/main/kotlin/me/ahoo/test/asserts/Jdk.kt
+++ b/core/src/main/kotlin/me/ahoo/test/asserts/Jdk.kt
@@ -362,12 +362,16 @@ fun <T> Stream<T>?.assert(): ListAssert<T> = assertThat(this)
  * Creates a fluent assertion for Comparable objects.
  *
  * This extension function provides access to AssertJ's GenericComparableAssert methods for fluent testing
- * of comparable objects, enabling comparison operations.
+ * of comparable objects, enabling comparison operations. Types with more specific overloads (such as String)
+ * resolve to their dedicated assertion class instead.
  *
  * Example:
  * ```kotlin
- * val version = "2.0.0"
- * version.assert().isGreaterThan("1.0.0").isLessThan("3.0.0")
+ * class Version(val value: Int) : Comparable<Version> {
+ *     override fun compareTo(other: Version): Int = value.compareTo(other.value)
+ * }
+ *
+ * Version(2).assert().isGreaterThan(Version(1)).isLessThan(Version(3))
  * ```
  *
  * @param T The comparable type (must implement Comparable<T>)


### PR DESCRIPTION
## Summary

Follow-up to the review noted in #95: the misleading String-based Comparable example still existed in the library KDoc and both READMEs.

### Changes

- **`core/.../Jdk.kt`**: the `GenericComparableAssert` extension KDoc used `val version = "2.0.0"` — a `String` receiver actually resolves to the more specific `StringAssert` overload, so the example never exercised the documented overload. Replaced with a custom `Version : Comparable<Version>` example (identical to the compiler-verified example in the skill reference) and a note about more-specific overloads winning.
- **`README.md` / `README.zh-CN.md`**: same replacement in the Comparable sections (#95 fixed the signatures there but left the String examples), with the same note in both languages.

### Verification

- The example code is character-identical to the one compile- and run-verified in #95 (`Version(2).assert().isGreaterThan(Version(1)).isLessThan(Version(3))` plus the class definition).
- `./gradlew :core:test detekt` — all green after the KDoc change.

Documentation-only change; no behavior touched.
