### PR TITLE
[docs] : regenerate AGENTS.md with verified overload-resolution facts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Published artifact: `me.ahoo.test:fluent-assert-core`.
 ./gradlew build                                  # Build all modules
 ./gradlew :core:build                            # Build the core library only
 ./gradlew clean                                  # Remove Gradle build outputs
-./gradlew detekt                                 # Run Detekt
+./gradlew detekt                                 # Run Detekt (reports only, no auto-fix)
 ./gradlew detekt --auto-correct                  # Run Detekt with auto-correction
 ./gradlew code-coverage-report:koverXmlReport    # Generate aggregate Kover XML coverage
 ```
@@ -34,6 +34,8 @@ Tests use JUnit 5 and MockK. CI enables Gradle test retry with up to two retries
 
 Before committing changes to library behavior, run at least `./gradlew :core:test`. For broad changes, run `./gradlew build`.
 
+For suspected API bugs (wrong overload picked, wrong AssertJ type returned), write a failing test that reproduces the exact symptom and confirm RED before touching implementation. Overload resolution is decided by the static receiver type, so adding or widening an overload changes resolution for existing call sites — treat that as a behavior change.
+
 ## Project Structure
 
 ```text
@@ -41,6 +43,7 @@ core/                         # Published library module, source and tests live 
 dependencies/                 # Java platform module pinning dependency versions
 bom/                          # Published BOM for consumers
 code-coverage-report/         # Aggregate Kover/Jacoco reporting module, not published
+skills/                       # fluent-assert skill plugin sources (SKILL.md, FULL-API.md, evals)
 config/detekt/detekt.yml      # Detekt rules
 .github/workflows/            # Coverage and package publishing workflows
 ```
@@ -69,9 +72,22 @@ fun Boolean?.assert(): BooleanAssert = BooleanAssert(this)
 fun <T> Iterable<T>?.assert(): IterableAssert<T> = assertThat(this)
 ```
 
-Most receivers are nullable, so callers can assert `null` values fluently. `AssertProvider<A>.assert()` is non-nullable because AssertJ handles provider delegation.
+All receivers are nullable (including the Comparable overload `fun <T : Comparable<T>?> T?.assert()`), so callers can assert `null` values fluently. `AssertProvider<A>.assert()` is non-nullable because AssertJ handles provider delegation.
+
+`JdkTime.kt` uses `assertThat(...) as XxxAssert` casts because AssertJ's temporal factories return wildcard self-references (`AbstractLocalDateAssert<?>`) and most concrete temporal assert classes have no public constructor; the file header explains this. Prefer direct constructors where they exist (as `JdkIO.kt` does).
 
 Do not add custom assertion semantics in this library unless requested. The library's value is the Kotlin extension API over AssertJ, not reimplementing AssertJ behavior.
+
+## Overload-Resolution Gotchas
+
+These are verified facts about how the overloads resolve; keep docs and examples consistent with them:
+
+- Primitive arrays (`IntArray`, `LongArray`, `ByteArray`, ...) are not `Array<T>` and fall back to `T?.assert()` → `ObjectAssert`. README documents `.toList()`/`.toTypedArray()` as the workaround; extending coverage is an ask-first API change.
+- A statically `CharSequence`-typed receiver resolves to `ObjectAssert`, not `StringAssert`.
+- `StringBuilder` implements `Comparable<StringBuilder>`, so `sb.assert()` resolves to `GenericComparableAssert<StringBuilder>` — still no string assertions.
+- `CompletionStage<V>.assert()` returns `CompletableFutureAssert<V>`; there is no `CompletionStageAssert`.
+- KDoc and skill examples must genuinely exercise the overload they document — e.g. a `String` receiver never demonstrates the `GenericComparableAssert` overload because it resolves to `StringAssert`.
+- When documenting resolution behavior, verify the claim with a throwaway test before writing it down; intuition about Kotlin overload resolution is unreliable here.
 
 ## Code Style
 
@@ -80,7 +96,7 @@ Do not add custom assertion semantics in this library unless requested. The libr
 - Keep KDoc examples short and executable-looking.
 - Follow existing test naming with backtick JUnit method names, for example `fun \`given Boolean when assert then BooleanAssert\`()`.
 - Tests commonly verify the returned AssertJ type with `value.assert().assert().isInstanceOf(...)`.
-- Detekt max line length is 300. Wildcard imports are allowed only for the packages configured in `config/detekt/detekt.yml`.
+- Detekt max line length is 300. Wildcard imports are allowed only for `java.util.*`, `org.hamcrest.Matchers.*`, `org.hamcrest.MatcherAssert.*`, and `org.junit.jupiter.api.Assertions.*` (see `config/detekt/detekt.yml`); `java.time.*` and others fail lint.
 
 ## Git & PR Workflow
 
@@ -94,6 +110,8 @@ Do not add custom assertion semantics in this library unless requested. The libr
 Coverage CI runs `./gradlew code-coverage-report:koverXmlReport --stacktrace` and uploads `code-coverage-report/build/reports/kover/report.xml`.
 
 Package publishing is triggered by GitHub Release creation or manual workflow dispatch. It publishes to GitHub Packages and Maven Central using signing and repository credentials from CI secrets.
+
+When changing the skill under `skills/fluent-assert/`, treat `skills/fluent-assert/references/FULL-API.md` and `evals/evals.json` as part of the change: factual claims must match the `:core` sources, and new guidance should get a regression eval prompt.
 
 ## Boundaries
 


### PR DESCRIPTION
## Summary

Regenerated `AGENTS.md` from the current state of the repository, folding in facts verified during the recent code review and PRs #93–#96.

### What changed

- **New "Overload-Resolution Gotchas" section** — five compiler-verified resolution facts (primitive arrays fall back to `ObjectAssert`; statically `CharSequence`-typed receivers → `ObjectAssert`; `StringBuilder` → `GenericComparableAssert<StringBuilder>`; `CompletionStage.assert()` returns `CompletableFutureAssert` — no `CompletionStageAssert` exists; examples must genuinely exercise the overload they document), plus the rule to verify resolution claims with a throwaway test before documenting them.
- **Architecture updated** — Comparable receiver is now nullable (landed in #93); documented why `JdkTime.kt` uses `as` casts (AssertJ wildcard self-types, missing public constructors) and to prefer direct constructors where available.
- **Testing updated** — suspected API bugs require a RED test first; overload changes are behavior changes because resolution follows the static receiver type.
- **Project Structure** — added `skills/`.
- **Publishing & CI** — skill changes must keep `FULL-API.md` and `evals.json` in sync with `:core` sources.
- **Code Style** — the wildcard-import allowlist is now spelled out (`java.util.*`, `org.hamcrest.Matchers.*`, `org.hamcrest.MatcherAssert.*`, `org.junit.jupiter.api.Assertions.*`); `java.time.*` explicitly fails lint.
- **Build & Run** — `./gradlew detekt` noted as report-only (matches `autoCorrect = false` from #93).

No source code touched; documentation for agents only.
