### PR TITLE
[fix] : stop assertThrownBy from leaking diagnostics into chained assertions

### DIFF
--- a/core/src/main/kotlin/me/ahoo/test/asserts/Throwable.kt
+++ b/core/src/main/kotlin/me/ahoo/test/asserts/Throwable.kt
@@ -60,12 +60,16 @@ fun <T : Throwable> assertThrownBy(
     shouldRaiseThrowable: () -> Unit
 ): ThrowableAssert<T> {
     val throwable = Assertions.catchThrowable(shouldRaiseThrowable)
-    return throwable
+    // describedAs/overridingErrorMessage persist on the assert instance's WritableAssertionInfo,
+    // so run the diagnostics on a throwaway instance and return a fresh one — otherwise chained
+    // assertions report their failures as type-check errors.
+    throwable
         .assert()
         .describedAs { "Expected ${throwableType.simpleName} to be thrown, but was: $throwable" }
         .isNotNull()
         .overridingErrorMessage(shouldBeInstance(throwable, throwableType).create())
-        .isInstanceOf(throwableType) as ThrowableAssert<T>
+        .isInstanceOf(throwableType)
+    return throwable.assert() as ThrowableAssert<T>
 }
 
 /**

--- a/core/src/test/kotlin/me/ahoo/test/asserts/ThrowableTest.kt
+++ b/core/src/test/kotlin/me/ahoo/test/asserts/ThrowableTest.kt
@@ -2,6 +2,7 @@ package me.ahoo.test.asserts
 
 import org.assertj.core.api.ThrowableAssert
 import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 
 class ThrowableTest {
@@ -37,5 +38,25 @@ class ThrowableTest {
                 throw IllegalStateException("wrong")
             }
         }.hasMessageContaining(IllegalArgumentException::class.java.name)
+    }
+
+    @Test
+    fun `given matching type when chained message assertion fails then failure reports message not type`() {
+        val error = assertThrows(AssertionError::class.java) {
+            assertThrownBy<IllegalArgumentException> {
+                throw IllegalArgumentException("boom-expected")
+            }.hasMessageContaining("wrong-fragment")
+        }
+        error.message!!.assert()
+            .contains("wrong-fragment")
+            .contains("boom-expected")
+        error.message!!.assert().doesNotContain("to be an instance of")
+    }
+
+    @Test
+    fun `given matching type and message when assertThrownBy then chained assertions pass`() {
+        assertThrownBy<IllegalArgumentException> {
+            throw IllegalArgumentException("boom-expected")
+        }.hasMessage("boom-expected").hasMessageContaining("boom")
     }
 }


### PR DESCRIPTION
Fixes #98

## Root Cause

`describedAs(...)` and `overridingErrorMessage(...)` mutate the assert instance's `WritableAssertionInfo` permanently. `assertThrownBy` applied both for its own nothing-thrown / wrong-type diagnostics **on the same instance it returned**, so every assertion chained afterwards inherited the sticky type-check override message and description — a failing `hasMessageContaining("wrong-fragment")` was reported as an instance-of failure even though the type check had passed.

## Fix

Minimal change to `Throwable.kt`: run the diagnostics chain on a throwaway assert instance and return a **fresh** `throwable.assert()` for chaining. The sticky state dies with the throwaway instance.

`assertThrownBy`'s own failure diagnostics are unchanged:
- nothing thrown → still `[Expected X to be thrown, but was: null]`
- wrong type → still the `shouldBeInstance` message

## Verification (TDD: RED → GREEN)

1. **RED**: added `given matching type when chained message assertion fails then failure reports message not type` — reproduces the issue's exact scenario (type matches, message fragment wrong). Before the fix it failed showing the misleading `to be an instance of` message instead of the expected `to contain` diagnostic.
2. **Fix applied** (single change, root cause only).
3. **GREEN**: full `./gradlew :core:test` passes — the new diagnostic test, a new chained-happy-path guard, and the pre-existing failure-mode tests that pin `assertThrownBy`'s own messages.
4. `./gradlew detekt` — clean.
