### PR TITLE
[chore] : bump version to 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ FluentAssert is a Kotlin library that provides fluent assertions for JDK types, 
 <dependency>
     <groupId>me.ahoo.test</groupId>
     <artifactId>fluent-assert-core</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -43,13 +43,13 @@ FluentAssert is a Kotlin library that provides fluent assertions for JDK types, 
 ### Gradle (Kotlin DSL)
 
 ```kotlin
-testImplementation("me.ahoo.test:fluent-assert-core:1.0.0")
+testImplementation("me.ahoo.test:fluent-assert-core:1.1.0")
 ```
 
 ### Gradle (Groovy DSL)
 
 ```gradle
-testImplementation 'me.ahoo.test:fluent-assert-core:1.0.0'
+testImplementation 'me.ahoo.test:fluent-assert-core:1.1.0'
 ```
 
 ## Quick Start

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -32,7 +32,7 @@ FluentAssert是一个为JDK类型提供流畅断言的Kotlin库，使您的测�
 <dependency>
     <groupId>me.ahoo.test</groupId>
     <artifactId>fluent-assert-core</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -40,13 +40,13 @@ FluentAssert是一个为JDK类型提供流畅断言的Kotlin库，使您的测�
 ### Gradle (Kotlin DSL)
 
 ```kotlin
-testImplementation("me.ahoo.test:fluent-assert-core:1.0.0")
+testImplementation("me.ahoo.test:fluent-assert-core:1.1.0")
 ```
 
 ### Gradle (Groovy DSL)
 
 ```gradle
-testImplementation 'me.ahoo.test:fluent-assert-core:1.0.0'
+testImplementation 'me.ahoo.test:fluent-assert-core:1.1.0'
 ```
 
 ## 快速开始

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 group=me.ahoo.test
-version=1.0.0
+version=1.1.0
 
 description=Fluent Assert
 website=https://github.com/Ahoo-Wang/FluentAssert

--- a/skills/fluent-assert/references/FULL-API.md
+++ b/skills/fluent-assert/references/FULL-API.md
@@ -15,7 +15,7 @@
 
 **Name:** FluentAssert
 
-**Version:** 1.0.0
+**Version:** 1.1.0
 
 **Description:** A Kotlin library providing fluent assertions for JDK types
 
@@ -33,7 +33,7 @@
 <dependency>
     <groupId>me.ahoo.test</groupId>
     <artifactId>fluent-assert-core</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -41,7 +41,7 @@
 ### Gradle (Kotlin DSL)
 
 ```kotlin
-testImplementation("me.ahoo.test:fluent-assert-core:1.0.0")
+testImplementation("me.ahoo.test:fluent-assert-core:1.1.0")
 ```
 
 ## Core Extension Functions


### PR DESCRIPTION
Bumps `fluent-assert-core` from 1.0.0 to **1.1.0** (minor).

**Why minor:** since 1.0.0 the library has one observable behavior change — #93 made nullable `Comparable` receivers resolve to `GenericComparableAssert` instead of `ObjectAssert` — plus the #99 `assertThrownBy` diagnostics fix. Docs (#95–#97) and CI cleanup (#94) are not part of the artifact.

Updates `gradle.properties` and all version references in `README.md`, `README.zh-CN.md`, and the skill's `FULL-API.md` (10 places total). Release `v1.1.0` follows after this merges.